### PR TITLE
Clarifying grasp options and removing jaco specific code

### DIFF
--- a/include/moveit_grasps/grasp_generator.h
+++ b/include/moveit_grasps/grasp_generator.h
@@ -94,6 +94,41 @@ enum grasp_axis_t
   Z_AXIS
 };
 
+struct GraspCandidateConfig
+{
+  GraspCandidateConfig()
+    : enable_corner_grasps_(false)
+    , enable_face_grasps_(false)
+    , enable_variable_angle_grasps_(false)
+    , enable_edge_grasps_(false)
+  {
+  }
+  void enableAll()
+  {
+    enable_corner_grasps_ = true;
+    enable_face_grasps_ = true;
+    enable_variable_angle_grasps_ = true;
+    enable_edge_grasps_ = true;
+  }
+  void disableAll()
+  {
+    enable_corner_grasps_ = false;
+    enable_face_grasps_ = false;
+    enable_variable_angle_grasps_ = false;
+    enable_edge_grasps_ = false;
+  }
+  void onlyEdgeGrasps()
+  {
+    disableAll();
+    enable_edge_grasps_ = true;
+  }
+
+  bool enable_corner_grasps_;
+  bool enable_face_grasps_;
+  bool enable_variable_angle_grasps_;
+  bool enable_edge_grasps_;
+};
+
 // Class
 class GraspGenerator
 {
@@ -137,7 +172,7 @@ public:
    * \param depth:            length of cuboid along local x-axis
    * \param width:            length of cuboid along local y-axis
    * \param height:           length of cuboid along local z-axis
-   * \param axis:             axis of cuboid to generate grasps around
+   * \param axis:             axis of cuboid to generate grasps along
    * \param grasp_data:       data describing end effector
    * \param grasp_candidates: possible grasps generated
    * \param only_edge_grasps: set to true if object is too wide to grap the face in this axis
@@ -145,7 +180,8 @@ public:
    */
   bool generateCuboidAxisGrasps(const Eigen::Affine3d& cuboid_pose, double depth, double width, double height,
                                 grasp_axis_t axis, const GraspDataPtr grasp_data,
-                                std::vector<GraspCandidatePtr>& grasp_candidates, bool only_edge_grasps);
+                                const GraspCandidateConfig& grasp_candidate_config,
+                                std::vector<GraspCandidatePtr>& grasp_candidates);
 
   /**
    * \brief helper function for adding grasps at corner of cuboid
@@ -320,10 +356,6 @@ private:
 
   // Transform from frame of box to global frame
   Eigen::Affine3d object_global_transform_;
-
-  // Visualization levels
-  bool show_grasp_arrows_;
-  double show_grasp_arrows_speed_;
 
   bool show_prefiltered_grasps_;
   double show_prefiltered_grasps_speed_;

--- a/include/moveit_grasps/state_validity_callback.h
+++ b/include/moveit_grasps/state_validity_callback.h
@@ -62,6 +62,7 @@ bool isGraspStateValid(const planning_scene::PlanningScene* planning_scene, bool
     visual_tools->publishRobotState(*robot_state, rviz_visual_tools::RED);
     planning_scene->isStateColliding(*robot_state, group->getName(), true);
     visual_tools->publishContactPoints(*robot_state, planning_scene);
+    visual_tools->trigger();
     ros::Duration(verbose_speed).sleep();
   }
   return false;

--- a/src/grasp_data.cpp
+++ b/src/grasp_data.cpp
@@ -210,6 +210,8 @@ bool GraspData::setGraspWidth(const double& percent_open, const double& min_fing
 bool GraspData::fingerWidthToGraspPosture(const double& distance_btw_fingers,
                                           trajectory_msgs::JointTrajectory& grasp_posture)
 {
+  // TODO (mlautman): Change this function to take in a method for translating joint values to grasp width
+  //       Currently this function simply interpolates between max open and max closed
   ROS_DEBUG_STREAM_NAMED("grasp_data", "Setting grasp posture to have distance_between_fingers of "
                                            << distance_btw_fingers);
 
@@ -222,41 +224,40 @@ bool GraspData::fingerWidthToGraspPosture(const double& distance_btw_fingers,
     return false;
   }
 
-  // TODO(davetcoleman): this is disgusting robot-specific code that must be removed
-  // Data from GDoc: https://docs.google.com/spreadsheets/d/1OXLqzDU7vjZhEis64XW2ziXoY39EwoqGZP6w3LAysvo/edit#gid=0
-  static const double SLOPE =
-      -6.881728199;  //-0.06881728199; //-14.51428571;  // TODO move this to the yaml file data!!
-  static const double INTERCEPT = 0.7097604907;  // 0.7097604907; //10.36703297;
-  double joint_position = SLOPE * distance_btw_fingers + INTERCEPT;
-
-  ROS_DEBUG_STREAM_NAMED("grasp_data", "Converted to joint position " << joint_position);
-
-  std::vector<double> joint_positions;
-  joint_positions.resize(6);
-  joint_positions[0] = joint_position;
-  joint_positions[1] = joint_position;
-
-  // JACO SPECIFIC
-  static const double FINGER_3_OFFSET = -0.1;  // open more than the others
-
-  // TODO get these values from joint_model, jaco specific
-  static const double MIN_JOINT_POSITION = 0.0;
-  static const double MAX_JOINT_POSITION = 0.742;
-
-  // special treatment - this joint should be opened more than the others
-  joint_positions[2] = joint_position + FINGER_3_OFFSET;
-  if (joint_positions[2] < MIN_JOINT_POSITION)
+  // NOTE: We assume a linear relationship between the actuated joint values and the distance between fingers.
+  //       This is probably incorrect but until we expose an interface for passing in a function to translate from
+  //       joint values to grasp width, it's the best we got...
+  // TODO (mlautman): Make it so that a user can pass in a function here.
+  std::vector<std::string> joint_names = pre_grasp_posture_.joint_names;
+  std::vector<double> grasp_pose = grasp_posture_.points[0].positions;
+  std::vector<double> pre_grasp_pose = pre_grasp_posture_.points[0].positions;
+  if (joint_names.size() != grasp_pose.size() || grasp_pose.size() != pre_grasp_pose.size())
   {
-    joint_positions[2] = MIN_JOINT_POSITION;
-  }
-  if (joint_positions[2] > MAX_JOINT_POSITION)
-  {
-    joint_positions[2] = MAX_JOINT_POSITION;
+    ROS_ERROR_NAMED("grasp_data", "Mismatched vector sizes joint_names.size()=%zu, grasp_pose.size()=%zu, and "
+                                  "pre_grasp_pose.size()=%zu",
+                    joint_names.size(), grasp_pose.size(), pre_grasp_pose.size());
+    return false;
   }
 
-  joint_positions[3] = 0;
-  joint_positions[4] = 0;
-  joint_positions[5] = 0;
+  std::vector<double> slope(joint_names.size());
+  std::vector<double> intercept(joint_names.size());
+  std::vector<double> joint_positions(joint_names.size());
+  for (std::size_t joint_index = 0; joint_index < joint_names.size(); joint_index++)
+  {
+    slope[joint_index] =
+        (max_finger_width_ - min_finger_width_) / (pre_grasp_pose[joint_index] - grasp_pose[joint_index]);
+    intercept[joint_index] = max_finger_width_ - slope[joint_index] * pre_grasp_pose[joint_index];
+
+    // Sanity check
+    double intercept2 = min_finger_width_ - slope[joint_index] * grasp_pose[joint_index];
+    ROS_ASSERT_MSG(intercept[joint_index] == intercept2, "we got different y intercept!! %.3f and %.3f",
+                   intercept[joint_index], intercept2);
+
+    joint_positions[joint_index] = (distance_btw_fingers - intercept[joint_index]) / slope[joint_index];
+
+    ROS_DEBUG_NAMED("grasp_data", "Converted joint %s to position %.3f", joint_names[joint_index].c_str(),
+                    joint_positions[joint_index]);
+  }
 
   return jointPositionsToGraspPosture(joint_positions, grasp_posture);
 }
@@ -264,29 +265,19 @@ bool GraspData::fingerWidthToGraspPosture(const double& distance_btw_fingers,
 bool GraspData::jointPositionsToGraspPosture(std::vector<double> joint_positions,
                                              trajectory_msgs::JointTrajectory& grasp_posture)
 {
-  // ROS_DEBUG_STREAM_NAMED("grasp_data","Moving fingers to joint positions using vector of size "
-  //                       << joint_positions.size());
-
-  // TODO (mlautman): This assumes that there is a single joint in the joints array defined in your yaml
-  //                  This is a bad assumption. Really this should look at all joints in the end effector
-  //                  group individual
-  if (grasp_posture_.joint_names.size() < 1)
+  for (std::size_t joint_index = 0; joint_index < pre_grasp_posture_.joint_names.size(); joint_index++)
   {
-    ROS_ERROR_STREAM_NAMED("grasp_data", "You must have at least one joint defined in joint_names");
-    return false;
-  }
+    const moveit::core::JointModel* joint = robot_model_->getJointModel(pre_grasp_posture_.joint_names[joint_index]);
+    ROS_ASSERT_MSG(joint->getVariableBounds().size() > 0, "joint->getVariableBounds() is empty for %s",
+                   pre_grasp_posture_.joint_names[joint_index].c_str());
+    const moveit::core::VariableBounds& bound = joint->getVariableBounds()[0];
 
-  const moveit::core::JointModel* joint = robot_model_->getJointModel(grasp_posture_.joint_names.front());
-  const moveit::core::VariableBounds& bound = joint->getVariableBounds()[0];
-
-  for (std::size_t i = 0; i < joint_positions.size(); ++i)
-  {
-    // Error check
-    if (joint_positions[i] > bound.max_position_ || joint_positions[i] < bound.min_position_)
+    if (joint_positions[joint_index] > bound.max_position_ || joint_positions[joint_index] < bound.min_position_)
     {
-      ROS_ERROR_STREAM_NAMED("grasp_data", "Requested joint " << i << " with value " << joint_positions[i]
-                                                              << " is beyond limits of " << bound.min_position_ << ", "
-                                                              << bound.max_position_);
+      ROS_ERROR_STREAM_NAMED("grasp_data", "Requested joint " << pre_grasp_posture_.joint_names[joint_index].c_str()
+                                                              << "at index" << joint_index << " with value "
+                                                              << joint_positions[joint_index] << " is beyond limits of "
+                                                              << bound.min_position_ << ", " << bound.max_position_);
       return false;
     }
   }


### PR DESCRIPTION
Adding GraspCandidateConfig struct to control which grasp options to generate.
Makes breaking changes to the api to remove shelf picking specific code
Uses linear interpolation between max and min joint values and open/close configurations rather than jaco specific values. 