### PR TITLE
factoring in the extents of the box to grasp score

### DIFF
--- a/config/moveit_grasps_config.yaml
+++ b/config/moveit_grasps_config.yaml
@@ -18,6 +18,8 @@ moveit_grasps:
     translation_x_score_weight: 0.0
     translation_y_score_weight: 0.0
     translation_z_score_weight: 4.0
+    overhang_x_score_weight: 0.0
+    overhang_y_score_weight: 0.0
 
     # Ideal grasp orientation (RPY)
     ideal_grasp_orientation_rpy: [0, 3.14159, 3.14159]

--- a/include/moveit_grasps/grasp_generator.h
+++ b/include/moveit_grasps/grasp_generator.h
@@ -292,8 +292,7 @@ public:
    */
   bool addGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr grasp_data,
                 std::vector<GraspCandidatePtr>& grasp_candidates, const Eigen::Affine3d& object_pose,
-                const Eigen::Vector3d& object_size,
-                double object_width);
+                const Eigen::Vector3d& object_size, double object_width);
 
   /**
    * \brief Score the generated suction grasp poses
@@ -303,7 +302,8 @@ public:
    * \param object size - the extents of the object being grasped
    * \return a score with positive being better
    */
-  double scoreSuctionGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data, const Eigen::Affine3d& cuboid_pose, const Eigen::Vector3d& object_size);
+  double scoreSuctionGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data,
+                           const Eigen::Affine3d& cuboid_pose, const Eigen::Vector3d& object_size);
 
   /**
    * \brief Score the generated finger grasp poses

--- a/include/moveit_grasps/grasp_generator.h
+++ b/include/moveit_grasps/grasp_generator.h
@@ -424,8 +424,11 @@ private:
   double translation_x_score_weight_;
   double translation_y_score_weight_;
   double translation_z_score_weight_;
+
+  // Suction gripper overhang
   double overhang_x_score_weight_;
   double overhang_y_score_weight_;
+  bool show_grasp_overhang_;
 
   // bounding_box::BoundingBox bounding_box_;
 

--- a/include/moveit_grasps/grasp_generator.h
+++ b/include/moveit_grasps/grasp_generator.h
@@ -287,22 +287,34 @@ public:
    * \param grasp_data data describing the end effector
    * \param grasp_candidates - list possible grasps
    * \param object_pose - pose of object to grasp
+   * \param object_size - size of object to grasp
    * \return true on success
    */
   bool addGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr grasp_data,
                 std::vector<GraspCandidatePtr>& grasp_candidates, const Eigen::Affine3d& object_pose,
+                const Eigen::Vector3d& object_size,
                 double object_width);
 
   /**
-   * \brief Score the generated grasp poses
+   * \brief Score the generated suction grasp poses
+   * \param grasp_pose - the pose of the grasp
+   * \param grasp_data - data describing the end effector
+   * \param cuboid_pose - the pose of the object being grasped
+   * \param object size - the extents of the object being grasped
+   * \return a score with positive being better
+   */
+  double scoreSuctionGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data, const Eigen::Affine3d& cuboid_pose, const Eigen::Vector3d& object_size);
+
+  /**
+   * \brief Score the generated finger grasp poses
    * \param grasp_pose - the pose of the grasp
    * \param grasp_data - data describing the end effector
    * \param object_pose - the pose of the object being grasped
    * \param percent_open - percentage that the grippers are open. 0.0 -> grippers are at object width + padding
-   * \return
+   * \return a score with positive being better
    */
-  double scoreGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data,
-                    const Eigen::Affine3d& object_pose, double percent_open = 0);
+  double scoreFingerGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data,
+                          const Eigen::Affine3d& object_pose, double percent_open);
 
   /**
    * \brief Get the grasp direction vector relative to the world frame
@@ -382,11 +394,6 @@ private:
                              const GraspDataPtr grasp_data, std::vector<GraspCandidatePtr>& grasp_candidates,
                              const GraspCandidateConfig grasp_candidate_config = GraspCandidateConfig());
 
-  double scoreSuctionGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data);
-
-  double scoreFingerGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data,
-                          const Eigen::Affine3d& object_pose, double percent_open);
-
   // class for publishing stuff to rviz
   moveit_visual_tools::MoveItVisualToolsPtr visual_tools_;
 
@@ -417,6 +424,8 @@ private:
   double translation_x_score_weight_;
   double translation_y_score_weight_;
   double translation_z_score_weight_;
+  double overhang_x_score_weight_;
+  double overhang_y_score_weight_;
 
   // bounding_box::BoundingBox bounding_box_;
 

--- a/include/moveit_grasps/grasp_scorer.h
+++ b/include/moveit_grasps/grasp_scorer.h
@@ -117,8 +117,8 @@ public:
    */
   static Eigen::Vector3d scoreGraspTranslation(const Eigen::Affine3d& grasp_pose, const Eigen::Affine3d& ideal_pose);
 
-  static Eigen::Vector3d scoreGraspOverhang(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data, const Eigen::Affine3d& object_pose, const Eigen::Vector3d& object_size);
-
+  static Eigen::Vector3d scoreGraspOverhang(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data,
+                                            const Eigen::Affine3d& object_pose, const Eigen::Vector3d& object_size);
 };
 
 }  // end namespace moveit_grasps

--- a/include/moveit_grasps/grasp_scorer.h
+++ b/include/moveit_grasps/grasp_scorer.h
@@ -116,6 +116,9 @@ public:
    *         0.0 -> pose is at the ideal translation in that axis
    */
   static Eigen::Vector3d scoreGraspTranslation(const Eigen::Affine3d& grasp_pose, const Eigen::Affine3d& ideal_pose);
+
+  static Eigen::Vector3d scoreGraspOverhang(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data, const Eigen::Affine3d& object_pose, const Eigen::Vector3d& object_size);
+
 };
 
 }  // end namespace moveit_grasps

--- a/include/moveit_grasps/grasp_scorer.h
+++ b/include/moveit_grasps/grasp_scorer.h
@@ -44,6 +44,7 @@
 #include <ros/ros.h>
 
 #include <moveit_grasps/grasp_data.h>
+#include <moveit_visual_tools/moveit_visual_tools.h>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -117,8 +118,9 @@ public:
    */
   static Eigen::Vector3d scoreGraspTranslation(const Eigen::Affine3d& grasp_pose, const Eigen::Affine3d& ideal_pose);
 
-  static Eigen::Vector3d scoreGraspOverhang(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data,
-                                            const Eigen::Affine3d& object_pose, const Eigen::Vector3d& object_size);
+  static Eigen::Vector2d scoreGraspOverhang(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data,
+                                            const Eigen::Affine3d& object_pose, const Eigen::Vector3d& object_size,
+                                            moveit_visual_tools::MoveItVisualToolsPtr visual_tools = NULL);
 };
 
 }  // end namespace moveit_grasps

--- a/src/grasp_generator.cpp
+++ b/src/grasp_generator.cpp
@@ -81,7 +81,6 @@ GraspGenerator::GraspGenerator(moveit_visual_tools::MoveItVisualToolsPtr visual_
   error += !rosparam_shortcuts::get(parent_name, nh_, "overhang_x_score_weight", overhang_x_score_weight_);
   error += !rosparam_shortcuts::get(parent_name, nh_, "overhang_y_score_weight", overhang_y_score_weight_);
 
-
   nh_.param("debug_top_grasps", debug_top_grasps_, false);
 
   std::vector<double> ideal_grasp_orientation_rpy;
@@ -791,7 +790,8 @@ bool GraspGenerator::addGrasp(const Eigen::Affine3d& grasp_pose, const GraspData
   return false;
 }
 
-double GraspGenerator::scoreSuctionGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data, const Eigen::Affine3d& cuboid_pose, const Eigen::Vector3d& object_size)
+double GraspGenerator::scoreSuctionGrasp(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data,
+                                         const Eigen::Affine3d& cuboid_pose, const Eigen::Vector3d& object_size)
 {
   ROS_DEBUG_STREAM_NAMED("grasp_generator.scoreGrasp",
                          "Scoring grasp at: \n\tpose:  ("
@@ -817,15 +817,13 @@ double GraspGenerator::scoreSuctionGrasp(const Eigen::Affine3d& grasp_pose, cons
   Eigen::Vector3d overhang_score = GraspScorer::scoreGraspOverhang(grasp_pose, grasp_data, cuboid_pose, object_size);
 
   std::size_t num_scores = 8;
-  double weights[num_scores] = {
-    orientation_x_score_weight_, orientation_y_score_weight_, orientation_z_score_weight_,
-    translation_x_score_weight_, translation_y_score_weight_, translation_z_score_weight_,
-    overhang_x_score_weight_, overhang_y_score_weight_
-  };
+  double weights[num_scores] = { orientation_x_score_weight_, orientation_y_score_weight_, orientation_z_score_weight_,
+                                 translation_x_score_weight_, translation_y_score_weight_, translation_z_score_weight_,
+                                 overhang_x_score_weight_,    overhang_y_score_weight_ };
 
   double scores[num_scores] = { orientation_scores[0], orientation_scores[1], orientation_scores[2],
                                 translation_scores[0], translation_scores[1], translation_scores[2],
-                                overhang_score[0], overhang_score[1]};
+                                overhang_score[0],     overhang_score[1] };
 
   double total_score = 0;
   double weight_total = 0;

--- a/src/grasp_generator.cpp
+++ b/src/grasp_generator.cpp
@@ -82,6 +82,7 @@ GraspGenerator::GraspGenerator(moveit_visual_tools::MoveItVisualToolsPtr visual_
   error += !rosparam_shortcuts::get(parent_name, nh_, "overhang_y_score_weight", overhang_y_score_weight_);
 
   nh_.param("debug_top_grasps", debug_top_grasps_, false);
+  nh_.param("show_grasp_overhang", show_grasp_overhang_, false);
 
   std::vector<double> ideal_grasp_orientation_rpy;
   error += !rosparam_shortcuts::get(parent_name, nh_, "ideal_grasp_orientation_rpy", ideal_grasp_orientation_rpy);
@@ -814,7 +815,12 @@ double GraspGenerator::scoreSuctionGrasp(const Eigen::Affine3d& grasp_pose, cons
   // get portion of score based on the translation
   Eigen::Vector3d translation_scores = GraspScorer::scoreGraspTranslation(grasp_pose, ideal_grasp);
 
-  Eigen::Vector3d overhang_score = GraspScorer::scoreGraspOverhang(grasp_pose, grasp_data, cuboid_pose, object_size);
+  // Score suction grasp overhang
+  Eigen::Vector2d overhang_score;
+  if (show_grasp_overhang_)
+    overhang_score = GraspScorer::scoreGraspOverhang(grasp_pose, grasp_data, cuboid_pose, object_size, visual_tools_);
+  else
+    overhang_score = GraspScorer::scoreGraspOverhang(grasp_pose, grasp_data, cuboid_pose, object_size);
 
   std::size_t num_scores = 8;
   double weights[num_scores] = { orientation_x_score_weight_, orientation_y_score_weight_, orientation_z_score_weight_,

--- a/src/grasp_scorer.cpp
+++ b/src/grasp_scorer.cpp
@@ -68,7 +68,7 @@ double GraspScorer::scoreDistanceToPalm(const Eigen::Affine3d& grasp_pose, const
 Eigen::Vector3d GraspScorer::scoreGraspTranslation(const Eigen::Affine3d& grasp_pose, const Eigen::Affine3d& ideal_pose)
 {
   // We assume that the ideal is in the middle
-  Eigen::Vector3d scores = -Eigen::Vector3d(grasp_pose.translation() - ideal_pose.translation()).array().pow(2);
+  Eigen::Vector3d scores = -Eigen::Vector3d(grasp_pose.translation() - ideal_pose.translation()).array();
 
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.scoreGraspTranslation",
                          "value, ideal, score:\n"
@@ -106,6 +106,128 @@ Eigen::Vector3d GraspScorer::scoreGraspTranslation(const Eigen::Affine3d& grasp_
                                                          << ", " << max_translations[1] << ", " << scores[1] << "\n"
                                                          << grasp_pose.translation()[2] << ", " << min_translations[2]
                                                          << ", " << max_translations[2] << ", " << scores[2] << "\n");
+
+  return scores;
+}
+
+Eigen::Vector3d GraspScorer::scoreGraspOverhang(const Eigen::Affine3d& grasp_pose,
+                                                const GraspDataPtr& grasp_data,
+                                                const Eigen::Affine3d& object_pose,
+                                                const Eigen::Vector3d& object_size)
+{
+  Eigen::Vector3d scores(0, 0, 0);
+
+
+  Eigen::Affine3d gripper_corner_tr = Eigen::Affine3d::Identity();
+  Eigen::Affine3d gripper_corner_tl = Eigen::Affine3d::Identity();
+  Eigen::Affine3d gripper_corner_br = Eigen::Affine3d::Identity();
+  Eigen::Affine3d gripper_corner_bl = Eigen::Affine3d::Identity();
+
+  Eigen::Affine3d box_corner_tr = Eigen::Affine3d::Identity();
+  Eigen::Affine3d box_corner_tl = Eigen::Affine3d::Identity();
+  Eigen::Affine3d box_corner_br = Eigen::Affine3d::Identity();
+  Eigen::Affine3d box_corner_bl = Eigen::Affine3d::Identity();
+
+  gripper_corner_tr.translation() = Eigen::Vector3d( grasp_data->active_suction_range_x_ / 2.0,  grasp_data->active_suction_range_y_ / 2.0, 0.0);
+  gripper_corner_tl.translation() = Eigen::Vector3d( grasp_data->active_suction_range_x_ / 2.0, -grasp_data->active_suction_range_y_ / 2.0, 0.0);
+  gripper_corner_br.translation() = Eigen::Vector3d(-grasp_data->active_suction_range_x_ / 2.0,  grasp_data->active_suction_range_y_ / 2.0, 0.0);
+  gripper_corner_bl.translation() = Eigen::Vector3d(-grasp_data->active_suction_range_x_ / 2.0, -grasp_data->active_suction_range_y_ / 2.0, 0.0);
+  box_corner_tr.translation() = Eigen::Vector3d( object_size[0] / 2.0,  object_size[1] / 2.0, 0.0);
+  box_corner_tl.translation() = Eigen::Vector3d( object_size[0] / 2.0, -object_size[1] / 2.0, 0.0);
+  box_corner_br.translation() = Eigen::Vector3d(-object_size[0] / 2.0,  object_size[1] / 2.0, 0.0);
+  box_corner_bl.translation() = Eigen::Vector3d(-object_size[0] / 2.0, -object_size[1] / 2.0, 0.0);
+
+  gripper_corner_tr = object_pose.inverse() * grasp_pose * gripper_corner_tr;
+  gripper_corner_tl = object_pose.inverse() * grasp_pose * gripper_corner_tl;
+  gripper_corner_br = object_pose.inverse() * grasp_pose * gripper_corner_br;
+  gripper_corner_bl = object_pose.inverse() * grasp_pose * gripper_corner_bl;
+
+  // bool debug_overhang = true;
+  // if (debug_overhang)
+  // {
+  //   box_corner_tr = object_pose * box_corner_tr;
+  //   box_corner_tl = object_pose * box_corner_tl;
+  //   box_corner_br = object_pose * box_corner_br;
+  //   box_corner_bl = object_pose * box_corner_bl;
+  //   gripper_corner_tr = object_pose * gripper_corner_tr;
+  //   gripper_corner_tl = object_pose * gripper_corner_tl;
+  //   gripper_corner_br = object_pose * gripper_corner_br;
+  //   gripper_corner_bl = object_pose * gripper_corner_bl;
+  //   visual_tools->publishAxisLabeled(gripper_corner_tr, "gripper_corner_tr", rviz_visual_tools::SMALL);
+  //   visual_tools->publishAxisLabeled(gripper_corner_tl, "gripper_corner_tl", rviz_visual_tools::SMALL);
+  //   visual_tools->publishAxisLabeled(gripper_corner_br, "gripper_corner_br", rviz_visual_tools::SMALL);
+  //   visual_tools->publishAxisLabeled(gripper_corner_bl, "gripper_corner_bl", rviz_visual_tools::SMALL);
+  //   visual_tools->publishAxisLabeled(box_corner_tr, "box_corner_tr", rviz_visual_tools::SMALL);
+  //   visual_tools->publishAxisLabeled(box_corner_tl, "box_corner_tl", rviz_visual_tools::SMALL);
+  //   visual_tools->publishAxisLabeled(box_corner_br, "box_corner_br", rviz_visual_tools::SMALL);
+  //   visual_tools->publishAxisLabeled(box_corner_bl, "box_corner_bl", rviz_visual_tools::SMALL);
+  //   visual_tools->trigger();
+  //   gripper_corner_tr = object_pose.inverse() * gripper_corner_tr;
+  //   gripper_corner_tl = object_pose.inverse() * gripper_corner_tl;
+  //   gripper_corner_br = object_pose.inverse() * gripper_corner_br;
+  //   gripper_corner_bl = object_pose.inverse() * gripper_corner_bl;
+  //   box_corner_tr = object_pose.inverse() * box_corner_tr;
+  //   box_corner_tl = object_pose.inverse() * box_corner_tl;
+  //   box_corner_br = object_pose.inverse() * box_corner_br;
+  //   box_corner_bl = object_pose.inverse() * box_corner_bl;
+  // }
+
+
+  double box_max_tx = std::max(box_corner_tr.translation().x(), box_corner_tl.translation().x());
+  double box_max_bx = std::max(box_corner_br.translation().x(), box_corner_bl.translation().x());
+  double box_max_x  = std::max(box_max_tx, box_max_bx);
+
+  double box_min_tx = std::min(box_corner_tr.translation().x(), box_corner_tl.translation().x());
+  double box_min_bx = std::min(box_corner_br.translation().x(), box_corner_bl.translation().x());
+  double box_min_x  = std::min(box_min_tx, box_min_bx);
+
+  double box_max_ty = std::max(box_corner_tr.translation().y(), box_corner_tl.translation().y());
+  double box_max_by = std::max(box_corner_br.translation().y(), box_corner_bl.translation().y());
+  double box_max_y  = std::max(box_max_ty, box_max_by);
+
+  double box_min_ty = std::min(box_corner_tr.translation().y(), box_corner_tl.translation().y());
+  double box_min_by = std::min(box_corner_br.translation().y(), box_corner_bl.translation().y());
+  double box_min_y  = std::min(box_min_ty, box_min_by);
+
+
+  double gripper_max_tx = std::max(gripper_corner_tr.translation().x(), gripper_corner_tl.translation().x());
+  double gripper_max_bx = std::max(gripper_corner_br.translation().x(), gripper_corner_bl.translation().x());
+  double gripper_max_x  = std::max(gripper_max_tx, gripper_max_bx);
+
+  double gripper_min_tx = std::min(gripper_corner_tr.translation().x(), gripper_corner_tl.translation().x());
+  double gripper_min_bx = std::min(gripper_corner_br.translation().x(), gripper_corner_bl.translation().x());
+  double gripper_min_x  = std::min(gripper_min_tx, gripper_min_bx);
+
+  double gripper_max_ty = std::max(gripper_corner_tr.translation().y(), gripper_corner_tl.translation().y());
+  double gripper_max_by = std::max(gripper_corner_br.translation().y(), gripper_corner_bl.translation().y());
+  double gripper_max_y  = std::max(gripper_max_ty, gripper_max_by);
+
+  double gripper_min_ty = std::min(gripper_corner_tr.translation().y(), gripper_corner_tl.translation().y());
+  double gripper_min_by = std::min(gripper_corner_br.translation().y(), gripper_corner_bl.translation().y());
+  double gripper_min_y  = std::min(gripper_min_ty, gripper_min_by);
+
+
+  if(gripper_max_x > box_max_x)
+    scores[0] -= gripper_max_x - box_max_x;
+
+  if(gripper_min_x < box_min_x)
+    scores[0] -= box_min_x - gripper_min_x;
+
+  if(gripper_max_y > box_max_y)
+    scores[1] -= gripper_max_y - box_max_y;
+
+  if(gripper_min_y < box_min_y)
+    scores[1] -= box_min_y - gripper_min_y;
+
+  ROS_DEBUG_STREAM_NAMED("grasp_scorer.overhang", "" << scores[0] << "\t" << scores[1]);
+
+  // if (debug_overhang)
+  // {
+  //   visual_tools->prompt("continue?");
+  //   visual_tools->deleteAllMarkers();
+  //   visual_tools->resetMarkerCounts();
+  //   visual_tools->trigger();
+  // }
 
   return scores;
 }

--- a/src/grasp_scorer.cpp
+++ b/src/grasp_scorer.cpp
@@ -132,6 +132,7 @@ Eigen::Vector3d GraspScorer::scoreGraspOverhang(const Eigen::Affine3d& grasp_pos
   gripper_corner_tl.translation() = Eigen::Vector3d( grasp_data->active_suction_range_x_ / 2.0, -grasp_data->active_suction_range_y_ / 2.0, 0.0);
   gripper_corner_br.translation() = Eigen::Vector3d(-grasp_data->active_suction_range_x_ / 2.0,  grasp_data->active_suction_range_y_ / 2.0, 0.0);
   gripper_corner_bl.translation() = Eigen::Vector3d(-grasp_data->active_suction_range_x_ / 2.0, -grasp_data->active_suction_range_y_ / 2.0, 0.0);
+
   box_corner_tr.translation() = Eigen::Vector3d( object_size[0] / 2.0,  object_size[1] / 2.0, 0.0);
   box_corner_tl.translation() = Eigen::Vector3d( object_size[0] / 2.0, -object_size[1] / 2.0, 0.0);
   box_corner_br.translation() = Eigen::Vector3d(-object_size[0] / 2.0,  object_size[1] / 2.0, 0.0);
@@ -141,37 +142,6 @@ Eigen::Vector3d GraspScorer::scoreGraspOverhang(const Eigen::Affine3d& grasp_pos
   gripper_corner_tl = object_pose.inverse() * grasp_pose * gripper_corner_tl;
   gripper_corner_br = object_pose.inverse() * grasp_pose * gripper_corner_br;
   gripper_corner_bl = object_pose.inverse() * grasp_pose * gripper_corner_bl;
-
-  // bool debug_overhang = true;
-  // if (debug_overhang)
-  // {
-  //   box_corner_tr = object_pose * box_corner_tr;
-  //   box_corner_tl = object_pose * box_corner_tl;
-  //   box_corner_br = object_pose * box_corner_br;
-  //   box_corner_bl = object_pose * box_corner_bl;
-  //   gripper_corner_tr = object_pose * gripper_corner_tr;
-  //   gripper_corner_tl = object_pose * gripper_corner_tl;
-  //   gripper_corner_br = object_pose * gripper_corner_br;
-  //   gripper_corner_bl = object_pose * gripper_corner_bl;
-  //   visual_tools->publishAxisLabeled(gripper_corner_tr, "gripper_corner_tr", rviz_visual_tools::SMALL);
-  //   visual_tools->publishAxisLabeled(gripper_corner_tl, "gripper_corner_tl", rviz_visual_tools::SMALL);
-  //   visual_tools->publishAxisLabeled(gripper_corner_br, "gripper_corner_br", rviz_visual_tools::SMALL);
-  //   visual_tools->publishAxisLabeled(gripper_corner_bl, "gripper_corner_bl", rviz_visual_tools::SMALL);
-  //   visual_tools->publishAxisLabeled(box_corner_tr, "box_corner_tr", rviz_visual_tools::SMALL);
-  //   visual_tools->publishAxisLabeled(box_corner_tl, "box_corner_tl", rviz_visual_tools::SMALL);
-  //   visual_tools->publishAxisLabeled(box_corner_br, "box_corner_br", rviz_visual_tools::SMALL);
-  //   visual_tools->publishAxisLabeled(box_corner_bl, "box_corner_bl", rviz_visual_tools::SMALL);
-  //   visual_tools->trigger();
-  //   gripper_corner_tr = object_pose.inverse() * gripper_corner_tr;
-  //   gripper_corner_tl = object_pose.inverse() * gripper_corner_tl;
-  //   gripper_corner_br = object_pose.inverse() * gripper_corner_br;
-  //   gripper_corner_bl = object_pose.inverse() * gripper_corner_bl;
-  //   box_corner_tr = object_pose.inverse() * box_corner_tr;
-  //   box_corner_tl = object_pose.inverse() * box_corner_tl;
-  //   box_corner_br = object_pose.inverse() * box_corner_br;
-  //   box_corner_bl = object_pose.inverse() * box_corner_bl;
-  // }
-
 
   double box_max_tx = std::max(box_corner_tr.translation().x(), box_corner_tl.translation().x());
   double box_max_bx = std::max(box_corner_br.translation().x(), box_corner_bl.translation().x());
@@ -220,14 +190,6 @@ Eigen::Vector3d GraspScorer::scoreGraspOverhang(const Eigen::Affine3d& grasp_pos
     scores[1] -= box_min_y - gripper_min_y;
 
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.overhang", "" << scores[0] << "\t" << scores[1]);
-
-  // if (debug_overhang)
-  // {
-  //   visual_tools->prompt("continue?");
-  //   visual_tools->deleteAllMarkers();
-  //   visual_tools->resetMarkerCounts();
-  //   visual_tools->trigger();
-  // }
 
   return scores;
 }

--- a/src/grasp_scorer.cpp
+++ b/src/grasp_scorer.cpp
@@ -68,7 +68,7 @@ double GraspScorer::scoreDistanceToPalm(const Eigen::Affine3d& grasp_pose, const
 Eigen::Vector3d GraspScorer::scoreGraspTranslation(const Eigen::Affine3d& grasp_pose, const Eigen::Affine3d& ideal_pose)
 {
   // We assume that the ideal is in the middle
-  Eigen::Vector3d scores = -Eigen::Vector3d(grasp_pose.translation() - ideal_pose.translation()).array();
+  Eigen::Vector3d scores = -Eigen::Vector3d(grasp_pose.translation() - ideal_pose.translation()).array().abs();
 
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.scoreGraspTranslation",
                          "value, ideal, score:\n"

--- a/src/grasp_scorer.cpp
+++ b/src/grasp_scorer.cpp
@@ -110,13 +110,10 @@ Eigen::Vector3d GraspScorer::scoreGraspTranslation(const Eigen::Affine3d& grasp_
   return scores;
 }
 
-Eigen::Vector3d GraspScorer::scoreGraspOverhang(const Eigen::Affine3d& grasp_pose,
-                                                const GraspDataPtr& grasp_data,
-                                                const Eigen::Affine3d& object_pose,
-                                                const Eigen::Vector3d& object_size)
+Eigen::Vector3d GraspScorer::scoreGraspOverhang(const Eigen::Affine3d& grasp_pose, const GraspDataPtr& grasp_data,
+                                                const Eigen::Affine3d& object_pose, const Eigen::Vector3d& object_size)
 {
   Eigen::Vector3d scores(0, 0, 0);
-
 
   Eigen::Affine3d gripper_corner_tr = Eigen::Affine3d::Identity();
   Eigen::Affine3d gripper_corner_tl = Eigen::Affine3d::Identity();
@@ -128,14 +125,18 @@ Eigen::Vector3d GraspScorer::scoreGraspOverhang(const Eigen::Affine3d& grasp_pos
   Eigen::Affine3d box_corner_br = Eigen::Affine3d::Identity();
   Eigen::Affine3d box_corner_bl = Eigen::Affine3d::Identity();
 
-  gripper_corner_tr.translation() = Eigen::Vector3d( grasp_data->active_suction_range_x_ / 2.0,  grasp_data->active_suction_range_y_ / 2.0, 0.0);
-  gripper_corner_tl.translation() = Eigen::Vector3d( grasp_data->active_suction_range_x_ / 2.0, -grasp_data->active_suction_range_y_ / 2.0, 0.0);
-  gripper_corner_br.translation() = Eigen::Vector3d(-grasp_data->active_suction_range_x_ / 2.0,  grasp_data->active_suction_range_y_ / 2.0, 0.0);
-  gripper_corner_bl.translation() = Eigen::Vector3d(-grasp_data->active_suction_range_x_ / 2.0, -grasp_data->active_suction_range_y_ / 2.0, 0.0);
+  gripper_corner_tr.translation() =
+      Eigen::Vector3d(grasp_data->active_suction_range_x_ / 2.0, grasp_data->active_suction_range_y_ / 2.0, 0.0);
+  gripper_corner_tl.translation() =
+      Eigen::Vector3d(grasp_data->active_suction_range_x_ / 2.0, -grasp_data->active_suction_range_y_ / 2.0, 0.0);
+  gripper_corner_br.translation() =
+      Eigen::Vector3d(-grasp_data->active_suction_range_x_ / 2.0, grasp_data->active_suction_range_y_ / 2.0, 0.0);
+  gripper_corner_bl.translation() =
+      Eigen::Vector3d(-grasp_data->active_suction_range_x_ / 2.0, -grasp_data->active_suction_range_y_ / 2.0, 0.0);
 
-  box_corner_tr.translation() = Eigen::Vector3d( object_size[0] / 2.0,  object_size[1] / 2.0, 0.0);
-  box_corner_tl.translation() = Eigen::Vector3d( object_size[0] / 2.0, -object_size[1] / 2.0, 0.0);
-  box_corner_br.translation() = Eigen::Vector3d(-object_size[0] / 2.0,  object_size[1] / 2.0, 0.0);
+  box_corner_tr.translation() = Eigen::Vector3d(object_size[0] / 2.0, object_size[1] / 2.0, 0.0);
+  box_corner_tl.translation() = Eigen::Vector3d(object_size[0] / 2.0, -object_size[1] / 2.0, 0.0);
+  box_corner_br.translation() = Eigen::Vector3d(-object_size[0] / 2.0, object_size[1] / 2.0, 0.0);
   box_corner_bl.translation() = Eigen::Vector3d(-object_size[0] / 2.0, -object_size[1] / 2.0, 0.0);
 
   gripper_corner_tr = object_pose.inverse() * grasp_pose * gripper_corner_tr;
@@ -145,48 +146,46 @@ Eigen::Vector3d GraspScorer::scoreGraspOverhang(const Eigen::Affine3d& grasp_pos
 
   double box_max_tx = std::max(box_corner_tr.translation().x(), box_corner_tl.translation().x());
   double box_max_bx = std::max(box_corner_br.translation().x(), box_corner_bl.translation().x());
-  double box_max_x  = std::max(box_max_tx, box_max_bx);
+  double box_max_x = std::max(box_max_tx, box_max_bx);
 
   double box_min_tx = std::min(box_corner_tr.translation().x(), box_corner_tl.translation().x());
   double box_min_bx = std::min(box_corner_br.translation().x(), box_corner_bl.translation().x());
-  double box_min_x  = std::min(box_min_tx, box_min_bx);
+  double box_min_x = std::min(box_min_tx, box_min_bx);
 
   double box_max_ty = std::max(box_corner_tr.translation().y(), box_corner_tl.translation().y());
   double box_max_by = std::max(box_corner_br.translation().y(), box_corner_bl.translation().y());
-  double box_max_y  = std::max(box_max_ty, box_max_by);
+  double box_max_y = std::max(box_max_ty, box_max_by);
 
   double box_min_ty = std::min(box_corner_tr.translation().y(), box_corner_tl.translation().y());
   double box_min_by = std::min(box_corner_br.translation().y(), box_corner_bl.translation().y());
-  double box_min_y  = std::min(box_min_ty, box_min_by);
-
+  double box_min_y = std::min(box_min_ty, box_min_by);
 
   double gripper_max_tx = std::max(gripper_corner_tr.translation().x(), gripper_corner_tl.translation().x());
   double gripper_max_bx = std::max(gripper_corner_br.translation().x(), gripper_corner_bl.translation().x());
-  double gripper_max_x  = std::max(gripper_max_tx, gripper_max_bx);
+  double gripper_max_x = std::max(gripper_max_tx, gripper_max_bx);
 
   double gripper_min_tx = std::min(gripper_corner_tr.translation().x(), gripper_corner_tl.translation().x());
   double gripper_min_bx = std::min(gripper_corner_br.translation().x(), gripper_corner_bl.translation().x());
-  double gripper_min_x  = std::min(gripper_min_tx, gripper_min_bx);
+  double gripper_min_x = std::min(gripper_min_tx, gripper_min_bx);
 
   double gripper_max_ty = std::max(gripper_corner_tr.translation().y(), gripper_corner_tl.translation().y());
   double gripper_max_by = std::max(gripper_corner_br.translation().y(), gripper_corner_bl.translation().y());
-  double gripper_max_y  = std::max(gripper_max_ty, gripper_max_by);
+  double gripper_max_y = std::max(gripper_max_ty, gripper_max_by);
 
   double gripper_min_ty = std::min(gripper_corner_tr.translation().y(), gripper_corner_tl.translation().y());
   double gripper_min_by = std::min(gripper_corner_br.translation().y(), gripper_corner_bl.translation().y());
-  double gripper_min_y  = std::min(gripper_min_ty, gripper_min_by);
+  double gripper_min_y = std::min(gripper_min_ty, gripper_min_by);
 
-
-  if(gripper_max_x > box_max_x)
+  if (gripper_max_x > box_max_x)
     scores[0] -= gripper_max_x - box_max_x;
 
-  if(gripper_min_x < box_min_x)
+  if (gripper_min_x < box_min_x)
     scores[0] -= box_min_x - gripper_min_x;
 
-  if(gripper_max_y > box_max_y)
+  if (gripper_max_y > box_max_y)
     scores[1] -= gripper_max_y - box_max_y;
 
-  if(gripper_min_y < box_min_y)
+  if (gripper_min_y < box_min_y)
     scores[1] -= box_min_y - gripper_min_y;
 
   ROS_DEBUG_STREAM_NAMED("grasp_scorer.overhang", "" << scores[0] << "\t" << scores[1]);


### PR DESCRIPTION
Previously, the suction grasps scoring function did not take into account the extents of the box and if the gripper would overhang the target object. This PR fixes this.