### PR TITLE
Adding more unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,5 +159,13 @@ target_link_libraries(grasp_generator_test
   ${Boost_LIBRARIES}
 )
 
+add_rostest_gtest(grasp_filter_test test/grasp_filter_test.test test/grasp_filter_test.cpp)
+target_link_libraries(grasp_filter_test
+  ${PROJECT_NAME}
+  ${PROJECT_NAME}_filter
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+)
+
 ## Test for correct C++ source code
 roslint_cpp()

--- a/test/grasp_data_test.cpp
+++ b/test/grasp_data_test.cpp
@@ -121,15 +121,11 @@ TEST_F(GraspDataTest, SetRobotState)
   grasp_data_->setRobotStatePreGrasp(robot_state);
   EXPECT_EQ(grasp_data_->pre_grasp_posture_.points[0].positions[0],
             robot_state->getJointPositions("panda_finger_joint1")[0]);
-  EXPECT_EQ(grasp_data_->pre_grasp_posture_.points[0].positions[1],
-            robot_state->getJointPositions("panda_finger_joint2")[0]);
 
   // Grasp
   grasp_data_->setRobotStateGrasp(robot_state);
   EXPECT_EQ(grasp_data_->grasp_posture_.points[0].positions[0],
             robot_state->getJointPositions("panda_finger_joint1")[0]);
-  EXPECT_EQ(grasp_data_->grasp_posture_.points[0].positions[1],
-            robot_state->getJointPositions("panda_finger_joint2")[0]);
 }
 
 TEST_F(GraspDataTest, fingerWidthToGraspPosture)
@@ -140,15 +136,11 @@ TEST_F(GraspDataTest, fingerWidthToGraspPosture)
   grasp_data_->setRobotStatePreGrasp(robot_state);
   EXPECT_EQ(grasp_data_->pre_grasp_posture_.points[0].positions[0],
             robot_state->getJointPositions("panda_finger_joint1")[0]);
-  EXPECT_EQ(grasp_data_->pre_grasp_posture_.points[0].positions[1],
-            robot_state->getJointPositions("panda_finger_joint2")[0]);
 
   // Grasp
   grasp_data_->setRobotStateGrasp(robot_state);
   EXPECT_EQ(grasp_data_->grasp_posture_.points[0].positions[0],
             robot_state->getJointPositions("panda_finger_joint1")[0]);
-  EXPECT_EQ(grasp_data_->grasp_posture_.points[0].positions[1],
-            robot_state->getJointPositions("panda_finger_joint2")[0]);
 }
 
 // TODO(davetcoleman): write test for remainder of this class

--- a/test/grasp_data_test.test
+++ b/test/grasp_data_test.test
@@ -4,7 +4,7 @@
       <arg name="load_robot_description" value="true"/>
     </include>
 
-    <test pkg="moveit_grasps" type="grasp_generator_test" test-name="grasp_generator_test" time-limit="300" args="">
+    <test pkg="moveit_grasps" type="grasp_data_test" test-name="grasp_data_test" time-limit="300" args="">
       <rosparam command="load" file="$(find moveit_grasps)/config_robot/panda_grasp_data.yaml"/>
       <rosparam command="load" file="$(find moveit_grasps)/config/moveit_grasps_config.yaml"/>
     </test>

--- a/test/grasp_filter_test.cpp
+++ b/test/grasp_filter_test.cpp
@@ -1,0 +1,153 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, PickNik LLC
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik LLC nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Henning Kayser
+ * Desc: Test filtering grasp candidates
+ */
+
+// C++
+#include <string>
+
+// ROS
+#include <ros/ros.h>
+
+// Testing
+#include <gtest/gtest.h>
+
+// Grasp
+#include <moveit_grasps/grasp_generator.h>
+#include <moveit_grasps/grasp_filter.h>
+#include <moveit_visual_tools/moveit_visual_tools.h>
+#include <moveit_grasps/grasp_data.h>
+
+namespace moveit_grasps
+{
+class GraspFilterTest : public ::testing::Test
+{
+public:
+  GraspFilterTest()
+    : nh_("~")
+    , verbose_(true)
+    , ee_group_name_("hand")
+  {
+    planning_scene_monitor_.reset(new planning_scene_monitor::PlanningSceneMonitor("robot_description"));
+    if (planning_scene_monitor_->getPlanningScene())
+    {
+      planning_scene_monitor_->startPublishingPlanningScene(planning_scene_monitor::PlanningSceneMonitor::UPDATE_SCENE,
+                                                            "grasping_planning_scene");
+      planning_scene_monitor_->getPlanningScene()->setName("grasping_planning_scene");
+    }
+    const robot_model::RobotModelConstPtr robot_model = planning_scene_monitor_->getRobotModel();
+    arm_jmg_ = robot_model->getJointModelGroup("panda_arm");
+    visual_tools_.reset(new moveit_visual_tools::MoveItVisualTools(robot_model->getModelFrame(), "/rviz_visual_tools",
+                                                                   planning_scene_monitor_));
+    grasp_generator_.reset(new moveit_grasps::GraspGenerator(visual_tools_));
+    grasp_filter_.reset(new moveit_grasps::GraspFilter(visual_tools_->getSharedRobotState(), visual_tools_));
+    grasp_data_.reset(new moveit_grasps::GraspData(nh_, ee_group_name_, visual_tools_->getRobotModel()));
+  }
+
+protected:
+  ros::NodeHandle nh_;
+  bool verbose_;
+  std::string ee_group_name_;
+  moveit_visual_tools::MoveItVisualToolsPtr visual_tools_;
+  moveit_grasps::GraspGeneratorPtr grasp_generator_;
+  moveit_grasps::GraspFilterPtr grasp_filter_;
+  moveit_grasps::GraspDataPtr grasp_data_;
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
+  const robot_model::JointModelGroup* arm_jmg_;
+
+};  // class GraspFilterTest
+
+TEST_F(GraspFilterTest, TestGraspFilter)
+{
+  // parameters for random cuboid pose and dimensions sampling
+  const double cuboid_size_min = 0.01;
+  const double cuboid_size_max = 0.0125;
+  const double xmin = 0.5;
+  const double xmax = 0.7;
+  const double ymin = -0.25;
+  const double ymax = 0.25;
+  const double zmin = 0.2;
+  const double zmax = 0.7;
+
+  // Generate grasps for a bunch of random objects
+  const std::size_t num_tests = 5;
+  for (std::size_t i = 0; i < num_tests; ++i)
+  {
+    // Generate random cuboid
+    rviz_visual_tools::RandomPoseBounds pose_bounds(xmin, xmax, ymin, ymax, zmin, zmax);
+    rviz_visual_tools::RandomCuboidBounds cuboid_bounds(cuboid_size_min, cuboid_size_max);
+
+    // push cuboid to planning scene
+    geometry_msgs::Pose object_pose;
+    double depth, width, height;
+    visual_tools_->generateRandomCuboid(object_pose, depth, width, height, pose_bounds, cuboid_bounds);
+
+    // Generate set of grasps for one object
+    std::vector<moveit_grasps::GraspCandidatePtr> grasp_candidates;
+
+    // Configure the desired types of grasps
+    moveit_grasps::GraspCandidateConfig grasp_generator_config = moveit_grasps::GraspCandidateConfig();
+    grasp_generator_config.disableAll();
+    grasp_generator_config.enable_face_grasps_ = true;
+    grasp_generator_config.generate_y_axis_grasps_ = true;
+    grasp_generator_config.generate_x_axis_grasps_ = true;
+    grasp_generator_config.generate_z_axis_grasps_ = true;
+
+    // generate grasps
+    grasp_generator_->generateGrasps(visual_tools_->convertPose(object_pose), depth, width, height, grasp_data_,
+        grasp_candidates, grasp_generator_config);
+
+    // Filter the grasp for only the ones that are reachable
+    bool filter_pregrasps = true;
+    std::size_t valid_grasps = grasp_filter_->filterGrasps(grasp_candidates, planning_scene_monitor_, arm_jmg_,
+        visual_tools_->getSharedRobotState(), filter_pregrasps);
+
+    EXPECT_FALSE(valid_grasps == 0) << "No valid grasps found after IK filtering";
+  }
+}
+}  // namespace moveit_grasps
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "grasp_filter_test");
+
+  // run test
+  int result = RUN_ALL_TESTS();
+
+  ros::shutdown();
+  return result;
+}

--- a/test/grasp_filter_test.cpp
+++ b/test/grasp_filter_test.cpp
@@ -87,7 +87,6 @@ protected:
   moveit_grasps::GraspDataPtr grasp_data_;
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
   const robot_model::JointModelGroup* arm_jmg_;
-
 };  // class GraspFilterTest
 
 TEST_F(GraspFilterTest, TestGraspFilter)
@@ -103,7 +102,7 @@ TEST_F(GraspFilterTest, TestGraspFilter)
   const double zmax = 0.7;
 
   // Generate grasps for a bunch of random objects
-  const std::size_t num_tests = 5;
+  const std::size_t num_tests = 1;
   for (std::size_t i = 0; i < num_tests; ++i)
   {
     // Generate random cuboid

--- a/test/grasp_filter_test.cpp
+++ b/test/grasp_filter_test.cpp
@@ -56,10 +56,7 @@ namespace moveit_grasps
 class GraspFilterTest : public ::testing::Test
 {
 public:
-  GraspFilterTest()
-    : nh_("~")
-    , verbose_(true)
-    , ee_group_name_("hand")
+  GraspFilterTest() : nh_("~"), verbose_(true), ee_group_name_("hand")
   {
     planning_scene_monitor_.reset(new planning_scene_monitor::PlanningSceneMonitor("robot_description"));
     if (planning_scene_monitor_->getPlanningScene())
@@ -127,12 +124,12 @@ TEST_F(GraspFilterTest, TestGraspFilter)
 
     // generate grasps
     grasp_generator_->generateGrasps(visual_tools_->convertPose(object_pose), depth, width, height, grasp_data_,
-        grasp_candidates, grasp_generator_config);
+                                     grasp_candidates, grasp_generator_config);
 
     // Filter the grasp for only the ones that are reachable
     bool filter_pregrasps = true;
     std::size_t valid_grasps = grasp_filter_->filterGrasps(grasp_candidates, planning_scene_monitor_, arm_jmg_,
-        visual_tools_->getSharedRobotState(), filter_pregrasps);
+                                                           visual_tools_->getSharedRobotState(), filter_pregrasps);
 
     EXPECT_FALSE(valid_grasps == 0) << "No valid grasps found after IK filtering";
   }

--- a/test/grasp_filter_test.test
+++ b/test/grasp_filter_test.test
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<launch>
+    <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+      <arg name="load_robot_description" value="true"/>
+    </include>
+
+    <test pkg="moveit_grasps" type="grasp_filter_test" test-name="grasp_filter_test" time-limit="300" args="">
+      <rosparam command="load" file="$(find moveit_grasps)/config_robot/panda_grasp_data.yaml"/>
+      <rosparam command="load" file="$(find moveit_grasps)/config/moveit_grasps_config.yaml"/>
+    </test>
+</launch>


### PR DESCRIPTION
This PR adds a unit test `grasp_filter_test` and fixes the `grasp_data_test` which wasn't functional before.

Looking at the other demos I don't really see any tests that should be converted directly.
The grasp generator tests are already quite extensive and grasp_pipeline and grasp_poses_visualizer focus on motion planning and visualization in RViz.

I found the following TODOs in the code:
  
    grasp_generator_test.cpp:270:// TODO(davetcoleman): Test all helper functions
    grasp_generator_test.cpp:271:// TODO(davetcoleman): Test addGrasp 
    grasp_generator_test.cpp:272:// TODO(davetcoleman): Test scoreGrasp
    grasp_data_test.cpp:93:  // TODO (mlautman-2/13/19): restore this test once https://github.com/ros-planning/panda_moveit_config/pull/20 is
    grasp_data_test.cpp:146:// TODO(davetcoleman): write test for remainder of this class

The first three are already being tested implicitly several times.
We could add extra unit tests for them probably using the same test data.

@mlautman is your TODO still relevant?
@davetcoleman does the last TODO mean that all functions should be tested separately?
 
